### PR TITLE
Mandatory improvements for production use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 etc
 examples
 bin
+target

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -97,7 +97,8 @@ pub fn init(cfg: Config) -> Result<()> {
 /// Initialize the BatchProcessor.
 ///
 pub fn init_processor(cfg: &Config) -> Result<BatchProcessor> {
-    let (tx, rx): (SyncSender<Event>, Receiver<Event>) = sync_channel(cfg.async_buffer_size());
+    let (tx, rx): (SyncSender<Event>, Receiver<Event>) =
+        sync_channel(cfg.async_buffer_size().unwrap_or(1000));
 
     if let Some(duration) = cfg.buffer_duration() {
         let ctx = tx.clone();

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -2,7 +2,6 @@
 // license that can be found in the LICENSE file.
 // Copyright 2009 The gelf_logger Authors. All rights reserved.
 
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{Receiver, sync_channel, SyncSender};
 use std::thread;
 use std::time::Duration;
@@ -90,9 +89,8 @@ pub fn init(cfg: Config) -> Result<()> {
     let log_level = log::Level::from(&gelf_level);
 
     let logger = GelfLogger::new(log_level);
-    let arx = Arc::new(Mutex::new(rx));
     thread::spawn(move || {
-        let _ = Buffer::new(arx, GelfTcpOutput::from(&cfg)).run();
+        let _ = Buffer::new(rx, GelfTcpOutput::from(&cfg)).run();
     });
 
     log::set_boxed_logger(Box::new(logger)).unwrap();

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -152,8 +152,13 @@ pub fn flush() -> Result<()> {
     processor().flush()
 }
 
+/// Trait for async batch processing of `GelfRecord`.
 pub trait Batch {
+    /// Send the `GelfRecord` in the async batch processor
+    ///
+    /// Records will actually be sent depending on configuration options
     fn send(&self, rec: &GelfRecord) -> Result<()>;
+    /// Flushes buffered records to the network
     fn flush(&self) -> Result<()>;
 }
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -97,7 +97,7 @@ pub fn init(cfg: Config) -> Result<()> {
 /// Initialize the BatchProcessor.
 ///
 pub fn init_processor(cfg: &Config) -> Result<BatchProcessor> {
-    let (tx, rx): (SyncSender<Event>, Receiver<Event>) = sync_channel(10_000_000);
+    let (tx, rx): (SyncSender<Event>, Receiver<Event>) = sync_channel(cfg.async_buffer_size());
 
     if let Some(duration) = cfg.buffer_duration() {
         let ctx = tx.clone();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -11,6 +11,7 @@ use crate::output::GelfTcpOutput;
 use crate::result::Error;
 
 /// Enum used to send commands over the channel.
+#[derive(Debug)]
 pub enum Event {
     /// Command to force the flush of the buffer.
     Flush,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,9 +2,8 @@
 // license that can be found in the LICENSE file.
 // Copyright 2009 The gelf_logger Authors. All rights reserved.
 
-use std::sync::mpsc::{Receiver, SyncSender};
-use std::thread;
-use std::time::Duration;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
 
 use serde_gelf::GelfRecord;
 
@@ -12,25 +11,11 @@ use crate::output::GelfTcpOutput;
 use crate::result::Error;
 
 /// Enum used to send commands over the channel.
-#[derive(Clone, Debug)]
 pub enum Event {
     /// Command to force the flush of the buffer.
-    Send,
+    Flush,
     /// Command used to send a record into the buffer.
     Data(GelfRecord),
-}
-
-/// Metronome to send all buffered record into network
-pub struct Metronome;
-
-impl Metronome {
-    /// Start the metronome
-    pub fn start(frequency: u64, chan: SyncSender<Event>) {
-        thread::spawn(move || loop {
-            thread::sleep(Duration::from_millis(frequency));
-            let _ = chan.send(Event::Send);
-        });
-    }
 }
 
 /// struct to store a buffer of `GelfRecord`
@@ -40,36 +25,61 @@ pub struct Buffer {
     errors: Vec<Error>,
     output: GelfTcpOutput,
     buffer_size: Option<usize>,
+    buffer_duration: Option<Duration>,
 }
 
 impl Buffer {
     /// Initialize buffer
-    pub fn new(rx: Receiver<Event>, output: GelfTcpOutput, buffer_size: Option<usize>) -> Buffer {
+    pub fn new(
+        rx: Receiver<Event>,
+        output: GelfTcpOutput,
+        buffer_size: Option<usize>,
+        buffer_duration: Option<Duration>,
+    ) -> Buffer {
         Buffer {
             items: Vec::new(),
             errors: Vec::new(),
             rx,
             output,
             buffer_size,
+            buffer_duration,
         }
     }
     /// Buffer body (loop)
     pub fn run(&mut self) {
+        let mut last_send = Instant::now();
         loop {
-            match { self.rx.recv() } {
-                Ok(event) => match event {
-                    Event::Send => self.flush(),
-                    Event::Data(record) => {
-                        self.items.push(record);
-                        if let Some(max_buffer_size) = self.buffer_size {
-                            if self.items.len() >= max_buffer_size {
-                                self.flush();
-                            }
+            let time_to_wait = self
+                .buffer_duration
+                .map(|duration| duration.checked_sub(Instant::now().duration_since(last_send)))
+                .unwrap_or(None); // flatten() would have been more explicit here bit it is not stable yet
+
+            let event = match time_to_wait {
+                None => match self.rx.recv() {
+                    Ok(e) => e,
+                    Err(_) => return,
+                },
+                Some(duration) => match self.rx.recv_timeout(duration) {
+                    Ok(e) => e,
+                    Err(e) => match e {
+                        RecvTimeoutError::Timeout => Event::Flush,
+                        RecvTimeoutError::Disconnected => return,
+                    },
+                },
+            };
+
+            match event {
+                Event::Flush => self.flush(),
+                Event::Data(record) => {
+                    self.items.push(record);
+                    if let Some(max_buffer_size) = self.buffer_size {
+                        if self.items.len() >= max_buffer_size {
+                            self.flush();
                         }
                     }
-                },
-                Err(_) => return,
+                }
             }
+            last_send = Instant::now();
         }
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -34,7 +34,6 @@ impl Metronome {
 }
 
 /// struct to store a buffer of `GelfRecord`
-#[derive(Debug)]
 pub struct Buffer {
     items: Vec<GelfRecord>,
     rx: Receiver<Event>,
@@ -68,7 +67,6 @@ impl Buffer {
                                 }
                                 self.errors.clear();
                             }
-                            thread::sleep(Duration::from_millis(100));
                         }
                     },
                     Event::Data(record) => self.items.push(record),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -62,11 +62,11 @@ impl Buffer {
                         Err(exc) => {
                             self.errors.push(exc);
                             if self.errors.len() >= 5 {
-                                println!("Too many errors !");
+                                eprintln!("Many errors occurred while sending GELF logs event!");
                                 for err in self.errors.iter() {
-                                    println!("{:?}", err);
+                                    eprintln!(">> {:?}", err);
                                 }
-                                std::process::exit(0x0100);
+                                self.errors.clear();
                             }
                             thread::sleep(Duration::from_millis(100));
                         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,11 +31,11 @@ pub struct ConfigBuilder {
     port: u64,
     null_character: bool,
     use_tls: bool,
+    async_buffer_size: usize,
     buffer_size: Option<usize>,
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
 }
-
 
 impl ConfigBuilder {
     /// Load configuration using the given `path` file.
@@ -71,6 +71,7 @@ impl ConfigBuilder {
             port: 12202,
             null_character: true,
             use_tls: true,
+            async_buffer_size: 1000, // sane default
             buffer_size: None,
             buffer_duration: None,
             additional_fields: BTreeMap::default(),
@@ -102,6 +103,22 @@ impl ConfigBuilder {
         self.use_tls = use_tls;
         self
     }
+    /// Set the asynchronous buffer size. This buffer is placed between the log subsystem
+    /// and the network sender. This represent the maximum number of message the system
+    /// will buffer before blocking while waiting for message to be actually sent to the
+    /// remote server.
+    ///
+    /// Default: 1000
+    ///
+    /// ### Warning
+    ///
+    /// This actually allocates a buffer of this size, if you set a high value here,
+    /// is will eat a large amount of memory.
+    pub fn set_async_buffer_size(mut self, async_buffer_size: usize) -> ConfigBuilder {
+        self.async_buffer_size = async_buffer_size;
+        self
+    }
+
     /// Sets the upperbound limit on the number of records that can be placed in the buffer, once
     /// this size has been reached, the buffer will be sent to the remote server.
     pub fn set_buffer_size(mut self, buffer_size: usize) -> ConfigBuilder {
@@ -120,7 +137,10 @@ impl ConfigBuilder {
         self
     }
     /// Adds multiple additional data which will be append to each log entry.
-    pub fn extend_additional_fields(mut self, additional_fields: BTreeMap<Value, Value>) -> ConfigBuilder {
+    pub fn extend_additional_fields(
+        mut self,
+        additional_fields: BTreeMap<Value, Value>,
+    ) -> ConfigBuilder {
         self.additional_fields.extend(additional_fields);
         self
     }
@@ -132,6 +152,7 @@ impl ConfigBuilder {
             port: self.port,
             null_character: self.null_character,
             use_tls: self.use_tls,
+            async_buffer_size: self.async_buffer_size,
             buffer_size: self.buffer_size,
             buffer_duration: self.buffer_duration,
             additional_fields: self.additional_fields,
@@ -147,6 +168,7 @@ pub struct Config {
     port: u64,
     null_character: bool,
     use_tls: bool,
+    async_buffer_size: usize,
     buffer_size: Option<usize>,
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
@@ -194,23 +216,48 @@ impl Config {
 
     /// The threshold for this logger to level. Logging messages which are less severe than level
     /// will be ignored.
-    pub fn level(&self) -> &GelfLevel { &self.level }
+    pub fn level(&self) -> &GelfLevel {
+        &self.level
+    }
     /// The name of the remote server.
-    pub fn hostname(&self) -> &String { &self.hostname }
+    pub fn hostname(&self) -> &String {
+        &self.hostname
+    }
     /// The port of the remote host.
-    pub fn port(&self) -> &u64 { &self.port }
+    pub fn port(&self) -> &u64 {
+        &self.port
+    }
     /// Adds a NUL byte (`\0`) after each entry.
-    pub fn null_character(&self) -> &bool { &self.null_character }
+    pub fn null_character(&self) -> &bool {
+        &self.null_character
+    }
     /// Activate transport security.
-    pub fn use_tls(&self) -> &bool { &self.use_tls }
+    pub fn use_tls(&self) -> &bool {
+        &self.use_tls
+    }
+    /// Get the asynchronous buffer size. This buffer is placed between the log subsystem
+    /// and the network sender. This represent the maximum number of message the system
+    /// will buffer before blocking while waiting for message to be actually sent to the
+    /// remote server.
+    pub fn async_buffer_size(&self) -> usize {
+        self.async_buffer_size
+    }
     /// Get the upperbound limit on the number of records that can be placed in the buffer, once
     /// this size has been reached, the buffer will be sent to the remote server.
-    pub fn buffer_size(&self) -> &Option<usize> { &self.buffer_size }
+    pub fn buffer_size(&self) -> &Option<usize> {
+        &self.buffer_size
+    }
     /// Get the maximum lifetime (in milli seconds) of the buffer before send it to the remote
     /// server.
-    pub fn buffer_duration(&self) -> &Option<u64> { &self.buffer_duration }
+    pub fn buffer_duration(&self) -> &Option<u64> {
+        &self.buffer_duration
+    }
     /// Every additional data which will be append to each log entry.
-    pub fn additional_fields(&self) -> &BTreeMap<Value, Value> { &self.additional_fields }
+    pub fn additional_fields(&self) -> &BTreeMap<Value, Value> {
+        &self.additional_fields
+    }
     /// Returns a new builder.
-    pub fn builder() -> ConfigBuilder { ConfigBuilder::new() }
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub struct ConfigBuilder {
     port: u64,
     null_character: bool,
     use_tls: bool,
-    async_buffer_size: usize,
+    async_buffer_size: Option<usize>,
     buffer_size: Option<usize>,
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
@@ -71,7 +71,7 @@ impl ConfigBuilder {
             port: 12202,
             null_character: true,
             use_tls: true,
-            async_buffer_size: 1000, // sane default
+            async_buffer_size: None,
             buffer_size: None,
             buffer_duration: None,
             additional_fields: BTreeMap::default(),
@@ -115,7 +115,7 @@ impl ConfigBuilder {
     /// This actually allocates a buffer of this size, if you set a high value here,
     /// is will eat a large amount of memory.
     pub fn set_async_buffer_size(mut self, async_buffer_size: usize) -> ConfigBuilder {
-        self.async_buffer_size = async_buffer_size;
+        self.async_buffer_size = Some(async_buffer_size);
         self
     }
 
@@ -168,7 +168,7 @@ pub struct Config {
     port: u64,
     null_character: bool,
     use_tls: bool,
-    async_buffer_size: usize,
+    async_buffer_size: Option<usize>,
     buffer_size: Option<usize>,
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
@@ -239,7 +239,9 @@ impl Config {
     /// and the network sender. This represent the maximum number of message the system
     /// will buffer before blocking while waiting for message to be actually sent to the
     /// remote server.
-    pub fn async_buffer_size(&self) -> usize {
+    ///
+    /// If None is configured, it defaults to 1000
+    pub fn async_buffer_size(&self) -> Option<usize> {
         self.async_buffer_size
     }
     /// Get the upperbound limit on the number of records that can be placed in the buffer, once

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ pub struct ConfigBuilder {
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
     full_buffer_policy: Option<FullBufferPolicy>,
+    connect_timeout_ms: Option<u64>,
+    write_timeout_ms: Option<u64>,
 }
 
 impl ConfigBuilder {
@@ -77,6 +79,8 @@ impl ConfigBuilder {
             buffer_duration: None,
             additional_fields: BTreeMap::default(),
             full_buffer_policy: Some(FullBufferPolicy::Discard),
+            connect_timeout_ms: None,
+            write_timeout_ms: None,
         }
     }
     /// Sets threshold for this logger to level. Logging messages which are less severe than level
@@ -155,6 +159,16 @@ impl ConfigBuilder {
         self.full_buffer_policy = policy;
         self
     }
+    /// Set the TCP connect timeout.    
+    pub fn set_connect_timeout_ms(mut self, connect_timeout_ms: Option<u64>) -> ConfigBuilder {
+        self.connect_timeout_ms = connect_timeout_ms;
+        self
+    }
+    /// Set the TCP write timeout.    
+    pub fn set_write_timeout_ms(mut self, write_timeout_ms: Option<u64>) -> ConfigBuilder {
+        self.write_timeout_ms = write_timeout_ms;
+        self
+    }
 
     /// Invoke the builder and return a Config
     pub fn build(self) -> Config {
@@ -169,6 +183,8 @@ impl ConfigBuilder {
             buffer_duration: self.buffer_duration,
             additional_fields: self.additional_fields,
             full_buffer_policy: self.full_buffer_policy,
+            connect_timeout_ms: self.connect_timeout_ms,
+            write_timeout_ms: self.write_timeout_ms,
         }
     }
 }
@@ -205,6 +221,8 @@ pub struct Config {
     buffer_duration: Option<u64>,
     additional_fields: BTreeMap<Value, Value>,
     full_buffer_policy: Option<FullBufferPolicy>,
+    connect_timeout_ms: Option<u64>,
+    write_timeout_ms: Option<u64>,
 }
 
 impl Config {
@@ -295,6 +313,15 @@ impl Config {
     pub fn full_buffer_policy(&self) -> Option<FullBufferPolicy> {
         self.full_buffer_policy
     }
+    /// Get the write timeout in milliseconds
+    pub fn write_timeout_ms(&self) -> Option<u64> {
+        self.write_timeout_ms
+    }
+    /// Get the connect timeout in milliseconds
+    pub fn connect_timeout_ms(&self) -> Option<u64> {
+        self.connect_timeout_ms
+    }
+
     /// Returns a new builder.
     pub fn builder() -> ConfigBuilder {
         ConfigBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ extern crate serde_value_utils;
 extern crate serde_yaml;
 
 pub use batch::{flush, init, init_from_file, init_processor, processor, Batch, BatchProcessor};
-pub use buffer::{Buffer, Event, Metronome};
+pub use buffer::Buffer;
 pub use config::{Config, ConfigBuilder};
 pub use output::GelfTcpOutput;
 pub use result::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
     html_logo_url = "https://eu.api.ovh.com/images/com-square-bichro.png",
     html_favicon_url = "https://www.ovh.com/favicon.ico"
 )]
-//#![deny(warnings, missing_docs)]
+#![deny(warnings, missing_docs)]
 extern crate log;
 extern crate native_tls;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@
 //! }
 //! ```
 #![doc(
-html_logo_url = "https://eu.api.ovh.com/images/com-square-bichro.png",
-html_favicon_url = "https://www.ovh.com/favicon.ico",
+    html_logo_url = "https://eu.api.ovh.com/images/com-square-bichro.png",
+    html_favicon_url = "https://www.ovh.com/favicon.ico"
 )]
 //#![deny(warnings, missing_docs)]
 extern crate log;
@@ -84,7 +84,7 @@ extern crate serde_value;
 extern crate serde_value_utils;
 extern crate serde_yaml;
 
-pub use batch::{flush, init, init_from_file, processor, BatchProcessor, Batch};
+pub use batch::{flush, init, init_from_file, init_processor, processor, Batch, BatchProcessor};
 pub use buffer::{Buffer, Event, Metronome};
 pub use config::{Config, ConfigBuilder};
 pub use output::GelfTcpOutput;
@@ -98,5 +98,3 @@ mod logger;
 mod macros;
 mod output;
 mod result;
-
-

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,7 +8,7 @@ use serde_gelf::GelfRecord;
 use crate::batch::processor;
 
 pub struct GelfLogger {
-    level: Level
+    level: Level,
 }
 
 impl Log for GelfLogger {
@@ -18,7 +18,9 @@ impl Log for GelfLogger {
     fn log(&self, record: &Record) {
         let _ = processor().send(&GelfRecord::from(record));
     }
-    fn flush(&self) {}
+    fn flush(&self) {
+        let _ = processor().flush();
+    }
 }
 
 impl GelfLogger {

--- a/src/result.rs
+++ b/src/result.rs
@@ -10,7 +10,7 @@ use crate::buffer::Event;
 /// Enum to represent errors
 #[derive(Debug)]
 pub enum Error {
-    // Error raised when  the channel gets disconnect or the async buffer is full
+    /// Error raised when  the channel gets disconnect or the async buffer is full
     FullChannelError(TrySendError<Event>),
     /// Error raised if the program failed to send a record into the channel.
     ChannelError(SendError<Event>),


### PR DESCRIPTION
Hi, 

Here is some improvements to make this crate a bit more production ready:
- do not quit the program if there are too much errors (a lib must _never_ take the responsibility of this)
- honor the buffer_size config option (the config option was there, but never used)
- remove useless `Arc<Mutex>` in `Buffer` struct
- keep tcp connection open, reconnect on network errors
- remove various hardcoded thread::sleep()
- remove hardcoded insane 10_000_000 `sync_channel` bound which eats 2GB (!!!) of RAM because sync_channel always allocate the totality of the buffer, the sync_channel size can now be configured (1000 by default)
- export `init_processor` so rust-log4rs-gelf create do not have to know what struct to create in order to initialize properly the `BatchProcessor`
- implement log::Log::flush (flushes the BatchProcessor)
- non blocking logging, even if the buffer is full: a failure in the logging subsystem must not block the application from working 
- remove `Metronome`. metronome logic is implemented with `recv_timeout` directly in `Buffer` loop. It seems to be a better option to me than the outer thread filling the buffer with `Send` events.
- configurable net timeouts

There are still some room for other improvements:
- exponential backoff on reconnection
